### PR TITLE
Standardize functions to match with other authsignal sdks

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ AUTHSIGNAL_SERVER_API_ENDPOINT=https://au.signal.authsignal.com/v1
 
 ## Usage
 
-Authsignal's server side signal API has five main calls `trackAction`, `getAction`, `getUser`, `enrollVerifiedAuthenticator`, `verifyChallenge`
+Authsignal's server side signal API has five main calls `track`, `getAction`, `getUser`, `enrollVerifiedAuthenticator`, `verifyChallenge`
 
 For more details on these api calls, refer to our [official PHP SDK docs](https://docs.authsignal.com/sdks/server/php#trackaction).
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ AUTHSIGNAL_SERVER_API_ENDPOINT=https://au.signal.authsignal.com/v1
 
 ## Usage
 
-Authsignal's server side signal API has five main calls `trackAction`, `getAction`, `getUser`, `enrollAuthenticator`, `verifyChallenge`
+Authsignal's server side signal API has five main calls `trackAction`, `getAction`, `getUser`, `enrollVerifiedAuthenticator`, `verifyChallenge`
 
 For more details on these api calls, refer to our [official PHP SDK docs](https://docs.authsignal.com/sdks/server/php#trackaction).
 

--- a/lib/Authsignal/Authsignal.php
+++ b/lib/Authsignal/Authsignal.php
@@ -139,9 +139,9 @@ abstract class Authsignal
    * @param  Array   $authenticator The authenticator object
    * @return Array  The authsignal response
    */
-  public static function enrolAuthenticator(string $userId, Array $authenticator)
+  public static function enrollVerifiedAuthenticator(string $userId, Array $authenticator)
   {
-    $response = self::enrollAuthenticator($userId, $authenticator);
+    $response = self::enrollVerifiedAuthenticator($userId, $authenticator);
 
     return $response;
   }
@@ -152,7 +152,7 @@ abstract class Authsignal
    * @param  Array   $authenticator The authenticator object
    * @return Array  The authsignal response
    */
-  public static function enrollAuthenticator(string $userId, Array $authenticator)
+  public static function enrollVerifiedAuthenticator(string $userId, Array $authenticator)
   {
     $request = new AuthsignalClient();
     $userId = urlencode($userId);

--- a/lib/Authsignal/Authsignal.php
+++ b/lib/Authsignal/Authsignal.php
@@ -118,21 +118,6 @@ abstract class Authsignal
   }
 
   /**
-   * Identify
-   * @param  string  $userId The userId of the user you are tracking the action for
-   * @param  Array  $user The user object with email
-   * @return Array  The authsignal response
-   */
-  public static function identify(string $userId, Array $user)
-  {
-    $request = new AuthsignalClient();
-    $userId = urlencode($userId);
-    list($response, $request) = $request->send("/users/{$userId}", $user, 'post');
-
-    return $response;
-  }
-
-  /**
    * Enroll Authenticators
    * @param  string  $userId The userId of the user you are tracking the action for
    * @param  Array   $authenticator The authenticator object

--- a/lib/Authsignal/Authsignal.php
+++ b/lib/Authsignal/Authsignal.php
@@ -5,7 +5,7 @@ use Firebase\JWT\Key;
 
 abstract class Authsignal
 {
-  const VERSION = '0.1.5';
+  const VERSION = '1.0.0';
 
   public static $apiKey;
 

--- a/lib/Authsignal/Authsignal.php
+++ b/lib/Authsignal/Authsignal.php
@@ -133,20 +133,6 @@ abstract class Authsignal
   }
 
   /**
-   * @deprecated
-   * Enrol Authenticators
-   * @param  string  $userId The userId of the user you are tracking the action for
-   * @param  Array   $authenticator The authenticator object
-   * @return Array  The authsignal response
-   */
-  public static function enrollVerifiedAuthenticator(string $userId, Array $authenticator)
-  {
-    $response = self::enrollVerifiedAuthenticator($userId, $authenticator);
-
-    return $response;
-  }
-
-  /**
    * Enroll Authenticators
    * @param  string  $userId The userId of the user you are tracking the action for
    * @param  Array   $authenticator The authenticator object

--- a/lib/Authsignal/Authsignal.php
+++ b/lib/Authsignal/Authsignal.php
@@ -71,7 +71,7 @@ abstract class Authsignal
    * @param  Array  $payload An array of attributes to track.
    * @return Array  The authsignal response
    */
-  public static function trackAction(string $userId, string $actionCode, Array $payload)
+  public static function track(string $userId, string $actionCode, Array $payload)
   {
     $request = new AuthsignalClient();
     $userId = urlencode($userId);

--- a/lib/Authsignal/Authsignal.php
+++ b/lib/Authsignal/Authsignal.php
@@ -67,16 +67,16 @@ abstract class Authsignal
   /**
    * Track an action
    * @param  string  $userId The userId of the user you are tracking the action for
-   * @param  string  $actionCode The action code that you are tracking
+   * @param  string  $action The action code that you are tracking
    * @param  Array  $payload An array of attributes to track.
    * @return Array  The authsignal response
    */
-  public static function track(string $userId, string $actionCode, Array $payload)
+  public static function track(string $userId, string $action, Array $payload)
   {
     $request = new AuthsignalClient();
     $userId = urlencode($userId);
-    $actionCode = urlencode($actionCode);
-    list($response, $request) = $request->send("/users/{$userId}/actions/{$actionCode}", $payload, 'post');
+    $action = urlencode($action);
+    list($response, $request) = $request->send("/users/{$userId}/actions/{$action}", $payload, 'post');
     
     return $response;
   }
@@ -84,16 +84,16 @@ abstract class Authsignal
   /**
    * Get an action
    * @param  string  $userId The userId of the user you are tracking the action for
-   * @param  string  $actionCode The action code that you are tracking
+   * @param  string  $action The action code that you are tracking
    * @param  string  $idempotencyKey The action code that you are tracking
    * @return Array  The authsignal response
    */
-  public static function getAction(string $userId, string $actionCode, string $idempotencyKey)
+  public static function getAction(string $userId, string $action, string $idempotencyKey)
   {
     $request = new AuthsignalClient();
     $userId = urlencode($userId);
-    $actionCode = urlencode($actionCode);
-    list($response, $request) = $request->send("/users/{$userId}/actions/{$actionCode}/{$idempotencyKey}", array(), 'get');
+    $action = urlencode($action);
+    list($response, $request) = $request->send("/users/{$userId}/actions/{$action}/{$idempotencyKey}", array(), 'get');
 
     return $response;
   }
@@ -162,7 +162,7 @@ abstract class Authsignal
     $otherClaim = (array)$decoded['other'];
 
     $decodedUserId = $otherClaim["userId"];
-    $decodedActionCode = $otherClaim["actionCode"];
+    $decodedActionCode = $otherClaim["action"];
     $decodedIdempotencyKey= $otherClaim["idempotencyKey"];
 
     if ($userId && ($userId != $decodedUserId))

--- a/lib/Authsignal/Authsignal.php
+++ b/lib/Authsignal/Authsignal.php
@@ -76,7 +76,7 @@ abstract class Authsignal
     $request = new AuthsignalClient();
     $userId = urlencode($userId);
     $actionCode = urlencode($actionCode);
-    list($response, $request) = $request->send("/users/${userId}/actions/${actionCode}", $payload, 'post');
+    list($response, $request) = $request->send("/users/{$userId}/actions/{$actionCode}", $payload, 'post');
     
     return $response;
   }
@@ -93,7 +93,7 @@ abstract class Authsignal
     $request = new AuthsignalClient();
     $userId = urlencode($userId);
     $actionCode = urlencode($actionCode);
-    list($response, $request) = $request->send("/users/${userId}/actions/${actionCode}/${idempotencyKey}", array(), 'get');
+    list($response, $request) = $request->send("/users/{$userId}/actions/{$actionCode}/{$idempotencyKey}", array(), 'get');
 
     return $response;
   }
@@ -111,7 +111,7 @@ abstract class Authsignal
 
     $redirectUrl = empty($redirectUrl) ? null : urlencode($redirectUrl);
   
-    $path = empty($redirectUrl) ? "/users/${userId}" : "/users/${userId}?redirectUrl=${redirectUrl}";
+    $path = empty($redirectUrl) ? "/users/{$userId}" : "/users/{$userId}?redirectUrl={$redirectUrl}";
     list($response, $request) = $request->send($path, null, 'get');
 
     return $response;
@@ -127,7 +127,7 @@ abstract class Authsignal
   {
     $request = new AuthsignalClient();
     $userId = urlencode($userId);
-    list($response, $request) = $request->send("/users/${userId}", $user, 'post');
+    list($response, $request) = $request->send("/users/{$userId}", $user, 'post');
 
     return $response;
   }
@@ -156,7 +156,7 @@ abstract class Authsignal
   {
     $request = new AuthsignalClient();
     $userId = urlencode($userId);
-    list($response, $request) = $request->send("/users/${userId}/authenticators", $authenticator, 'post');
+    list($response, $request) = $request->send("/users/{$userId}/authenticators", $authenticator, 'post');
 
     return $response;
   }

--- a/lib/Authsignal/AuthsignalRequestTransport.php
+++ b/lib/Authsignal/AuthsignalRequestTransport.php
@@ -72,7 +72,7 @@ class AuthsignalRequestTransport
     $curlOptions[CURLOPT_TIMEOUT] = 10;
     $curlOptions[CURLOPT_HTTPHEADER] = array(
       'Content-Type: application/json',
-      'Content-Length: ' . strlen($body)
+      'Content-Length: ' . (is_null($body) ? 0 : strlen($body))
     );
     $curlOptions[CURLOPT_HEADER] = true;
 

--- a/test/AuthsignalTest.php
+++ b/test/AuthsignalTest.php
@@ -88,7 +88,7 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
         $this->assertEquals($response["url"], $mockedResponse["url"]);
     }   
 
-    public function testenrollVerifiedAuthenticator() {
+    public function testEnrollVerifiedAuthenticator() {
         $mockedResponse = array(
             "authenticator" => array(
                 "userAuthenticatorId" => "9b2cfd40-7df2-4658-852d-a0c3456e5a2e",

--- a/test/AuthsignalTest.php
+++ b/test/AuthsignalTest.php
@@ -50,7 +50,7 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
             ));
 
         $response = Authsignal::track(userId: "123:test",
-                                            actionCode: "signIn",
+                                            action: "signIn",
                                             payload: $payload);
 
         $this->assertEquals($response["state"], "ALLOW");
@@ -68,7 +68,7 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
         self::$server->setResponseOfPath("/v1/users/123%3Atest/actions/signIn/5924a649-b5d3-4baf-a4ab-4b812dde97a04", new Response(json_encode($mockedResponse)));
 
         $response = Authsignal::getAction(userId: "123:test",
-                                            actionCode: "signIn",
+                                            action: "signIn",
                                             idempotencyKey: "5924a649-b5d3-4baf-a4ab-4b812dde97a04");
 
         $this->assertEquals($response["state"], "ALLOW");
@@ -136,7 +136,7 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
             'other' => [
                 'userId' => "123:test",
                 'state' => "CHALLENGE_SUCCEEDED",
-                'actionCode' => 'signIn',
+                'action' => 'signIn',
                 'idempotencyKey' => "5924a649-b5d3-4baf-a4ab-4b812dde97a0",
             ]
         ];
@@ -165,7 +165,7 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
             'other' => [
                 'userId' => "123:test",
                 'state' => "CHALLENGE_SUCCEEDED",
-                'actionCode' => 'signIn',
+                'action' => 'signIn',
                 'idempotencyKey' => "5924a649-b5d3-4baf-a4ab-4b812dde97a0",
             ]
         ];

--- a/test/AuthsignalTest.php
+++ b/test/AuthsignalTest.php
@@ -99,7 +99,7 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
         $this->assertEquals($response["email"], $mockedResponse["email"]);
     }
 
-    public function testEnrollAuthenticator() {
+    public function testenrollVerifiedAuthenticator() {
         $mockedResponse = array(
             "authenticator" => array(
                 "userAuthenticatorId" => "9b2cfd40-7df2-4658-852d-a0c3456e5a2e",
@@ -111,7 +111,7 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
 
         self::$server->setResponseOfPath("/v1/users/123%3Atest/authenticators", new Response(json_encode($mockedResponse)));
 
-        $response = Authsignal::enrollAuthenticator(userId: "123:test",
+        $response = Authsignal::enrollVerifiedAuthenticator(userId: "123:test",
                                                    authenticator: array("oobChannel" => "SMS"
                                                                 ,"phoneNumber" => "+6427000000"));
         

--- a/test/AuthsignalTest.php
+++ b/test/AuthsignalTest.php
@@ -49,7 +49,7 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
               "yourCustomNumber" => 1.12
             ));
 
-        $response = Authsignal::trackAction(userId: "123:test",
+        $response = Authsignal::track(userId: "123:test",
                                             actionCode: "signIn",
                                             payload: $payload);
 

--- a/test/AuthsignalTest.php
+++ b/test/AuthsignalTest.php
@@ -86,18 +86,7 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
         
         $this->assertEquals($response["isEnrolled"], $mockedResponse["isEnrolled"]);
         $this->assertEquals($response["url"], $mockedResponse["url"]);
-    }
-
-    public function testIdentify() {
-        $mockedResponse = array("userId" => "123:test",
-              "email" => "test@test.com");
-
-        self::$server->setResponseOfPath("/v1/users/123%3Atest", new Response(json_encode($mockedResponse)));
-        $response = Authsignal::identify(userId: "123:test", user: array("email" => "test@test.com"));
-
-        $this->assertEquals($response["userId"], $mockedResponse["userId"]);
-        $this->assertEquals($response["email"], $mockedResponse["email"]);
-    }
+    }   
 
     public function testenrollVerifiedAuthenticator() {
         $mockedResponse = array(


### PR DESCRIPTION
New version: **1.0.0**

**Breaking Changes**

Change `enrolAuthenticator` to `enrollVerifiedAuthenticator`

Change `trackAction` to `track`

Change track `actionCode` param to `action`

Change getAction `actionCode` param to `action`

Remove `identify` function



