### PR TITLE
Prevent undefined array key "error" exception.

### DIFF
--- a/lib/Authsignal/AuthsignalClient.php
+++ b/lib/Authsignal/AuthsignalClient.php
@@ -15,7 +15,7 @@ class AuthsignalClient
 
   public function handleApiError($response, $status)
   {
-    $type = $response['error'];
+    $type = $response['error'] ?? null;
     $msg  = $response['message'];
     switch ($status) {
       case 400:


### PR DESCRIPTION
Handle the case where the API HOSTNAME is incorrect, the `error` field may not be returned, and the exception will throw here (`undefined array key "error"`) instead of with the real cause.

This can occur if the HOSTNAME is set with a custom `.env` key, and the string used is the same as the one used for the `AUTHSIGNAL_SERVER_API_ENDPOINT` which includes the `/v1` at the end. 

So a request would go out for `hostname.com/v1/v1/...` which returns an exception without the error key.

This also occurs if an unsupported API url is wrong for any other reason. 