### PR TITLE
Fix undefined array key exception

### DIFF
--- a/lib/Authsignal/AuthsignalClient.php
+++ b/lib/Authsignal/AuthsignalClient.php
@@ -16,7 +16,7 @@ class AuthsignalClient
   public function handleApiError($response, $status)
   {
     $type = $response['error'] ?? null;
-    $msg  = $response['message'];
+    $msg  = $response['message'] ?? null;
     switch ($status) {
       case 400:
         throw new AuthsignalBadRequest($msg, $type, $status);


### PR DESCRIPTION
Similar to the `error` key issue, sometimes if the API was not configured correctly it may return an empty response, where this will cause an undefined array key exception.