### PR TITLE
Fix undefined "message" in error response as there was only "errorDescription" in the response array instead

### DIFF
--- a/lib/Authsignal/AuthsignalClient.php
+++ b/lib/Authsignal/AuthsignalClient.php
@@ -16,7 +16,7 @@ class AuthsignalClient
   public function handleApiError($response, $status)
   {
     $type = $response['error'] ?? null;
-    $msg  = $response['message'] ?? $response['errorDescription'] ?? null;
+    $msg  = $response['errorDescription'] ?? null;
     switch ($status) {
       case 400:
         throw new AuthsignalBadRequest($msg, $type, $status);

--- a/lib/Authsignal/AuthsignalClient.php
+++ b/lib/Authsignal/AuthsignalClient.php
@@ -16,7 +16,7 @@ class AuthsignalClient
   public function handleApiError($response, $status)
   {
     $type = $response['error'] ?? null;
-    $msg  = $response['message'];
+    $msg  = $response['message'] ?? $response['errorDescription'] ?? null;
     switch ($status) {
       case 400:
         throw new AuthsignalBadRequest($msg, $type, $status);


### PR DESCRIPTION
When the API calls fail because of no authenticators enabled, the response array only contains **["error" => "invalid_configuration", "errorDescription" => "No authenticators enabled. Go to https://portal.authsignal.com/organisations/tenants/authenticator to enable authenticators."**.

This PR fixes this by getting the "errorDescription" so that the error is clear to the SDK's consumers.