### PR TITLE
General improvements

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,5 @@
 {
     "workbench.colorCustomizations": {
-        "activityBar.background": "#2E1285",
-        "titleBar.activeBackground": "#4019BA",
-        "titleBar.activeForeground": "#FAF9FE"
+        "titleBar.inactiveBackground": "#4019BA",
     }
 }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Check out our [official PHP SDK documentation](https://docs.authsignal.com/sdks/
 ```php
 "require": {
     ...
-    "authsignal/authsignal-php" : "2.0.2"
+    "authsignal/authsignal-php" : "2.0.3"
     ...
 }
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Check out our [official PHP SDK documentation](https://docs.authsignal.com/sdks/
 ```php
 "require": {
     ...
-    "authsignal/authsignal-php" : "2.0.3"
+    "authsignal/authsignal-php" : "3.0.0"
     ...
 }
 ```

--- a/lib/Authsignal/Authsignal.php
+++ b/lib/Authsignal/Authsignal.php
@@ -161,7 +161,7 @@ abstract class Authsignal
    * @param  string  $userAuthenticatorId The userAuthenticatorId of the authenticator
    * @return Array  The authsignal response
   */
-  public static function deleteUserAuthenticator(string $userId, string $userAuthenticatorId) {
+  public static function deleteAuthenticator(string $userId, string $userAuthenticatorId) {
     if (empty($userId)) {
         throw new InvalidArgumentException('user_id cannot be empty');
     }

--- a/lib/Authsignal/Authsignal.php
+++ b/lib/Authsignal/Authsignal.php
@@ -63,7 +63,6 @@ abstract class Authsignal
     self::$apiVersion = $apiVersion;
   }
 
-
   /**
    * Track an action
    * @param  string  $userId The userId of the user you are tracking the action for
@@ -120,13 +119,9 @@ abstract class Authsignal
   public static function updateUser(string $userId, array $data)
   {
       $request = new AuthsignalClient();
-      
       $userId = urlencode($userId);
-  
-      $url = "/users/{$userId}";
-  
-      list($response, $request) = $request->send($url, $data, 'post');
-  
+      $path = "/users/{$userId}";
+      list($response, $request) = $request->send($path, $data, 'post');
       return $response;
   }
   
@@ -155,9 +150,8 @@ abstract class Authsignal
   {
     $request = new AuthsignalClient();
     $userId = urlencode($userId);
-    $url = "/users/{$userId}";
-    list($response, $request) = $request->send($url, null, 'delete');
-    
+    $path = "/users/{$userId}";
+    list($response, $request) = $request->send($path, null, 'delete');
     return $response;
   }
 
@@ -178,12 +172,12 @@ abstract class Authsignal
 
     $userId = urlencode($userId);
     $userAuthenticatorId = urlencode($userAuthenticatorId);
-    $url = "/users/{$userId}/authenticators/{$userAuthenticatorId}";
+    $path = "/users/{$userId}/authenticators/{$userAuthenticatorId}";
 
     $request = new AuthsignalClient();
 
     try {
-        list($response, $request) = $request->send($url, null, 'delete');
+        list($response, $request) = $request->send($path, null, 'delete');
         return $response;
     } catch (Exception $e) {
         throw new AuthsignalApiException($e->getMessage(), $path, $e);

--- a/lib/Authsignal/Authsignal.php
+++ b/lib/Authsignal/Authsignal.php
@@ -198,12 +198,13 @@ abstract class Authsignal
    * @param  string  $token  The JWT token string returned on a challenge response
    * @return Array  The authsignal response
    */
-  public static function validateChallenge(string $token, ?string $userId = null)
+  public static function validateChallenge(string $token, ?string $userId = null, ?string $action = null)
   {
     $request = new AuthsignalClient();
 
     $payload = [
       'userId' => $userId,
+      'action' => $action,
       'token' => $token
     ];
 

--- a/lib/Authsignal/Authsignal.php
+++ b/lib/Authsignal/Authsignal.php
@@ -208,6 +208,10 @@ abstract class Authsignal
       'token' => $token
     ];
 
+    $payload = array_filter($payload, function($value) {
+      return $value !== null;
+    });
+
     list($response, $request) = $request->send("/validate", $payload, 'post');
     
     return $response;

--- a/lib/Authsignal/Authsignal.php
+++ b/lib/Authsignal/Authsignal.php
@@ -202,10 +202,6 @@ abstract class Authsignal
       'token' => $token
     ];
 
-    $payload = array_filter($payload, function($value) {
-      return $value !== null;
-    });
-
     list($response, $request) = $request->send("/validate", $payload, 'post');
     
     return $response;

--- a/lib/Authsignal/Authsignal.php
+++ b/lib/Authsignal/Authsignal.php
@@ -5,7 +5,7 @@ use Firebase\JWT\Key;
 
 abstract class Authsignal
 {
-  const VERSION = '2.0.2';
+  const VERSION = '2.0.3';
 
   public static $apiKey;
 

--- a/lib/Authsignal/Authsignal.php
+++ b/lib/Authsignal/Authsignal.php
@@ -204,6 +204,10 @@ abstract class Authsignal
 
     list($response, $request) = $request->send("/validate", $payload, 'post');
     
+    if (isset($response['actionCode'])) {
+        unset($response['actionCode']);
+    }
+    
     return $response;
   }
 }

--- a/lib/Authsignal/Authsignal.php
+++ b/lib/Authsignal/Authsignal.php
@@ -5,7 +5,7 @@ use Firebase\JWT\Key;
 
 abstract class Authsignal
 {
-  const VERSION = '2.0.3';
+  const VERSION = '3.0.0';
 
   public static $apiKey;
 

--- a/lib/Authsignal/AuthsignalClient.php
+++ b/lib/Authsignal/AuthsignalClient.php
@@ -2,7 +2,7 @@
 
 class AuthsignalClient
 {
-  public static function apiUrl($url='')
+  public static function apiUrl($path='')
   {
     $apiEndpoint = getenv('AUTHSIGNAL_SERVER_API_ENDPOINT');
     if ( !$apiEndpoint ) {
@@ -10,7 +10,7 @@ class AuthsignalClient
       $apiVersion = Authsignal::getApiVersion();
       $apiEndpoint = $apiBase.'/'.$apiVersion;
     }
-    return $apiEndpoint.$url;
+    return $apiEndpoint.$path;
   }
 
   public function handleApiError($response, $status)
@@ -70,12 +70,18 @@ class AuthsignalClient
     }
   }
 
-  public function send($url, $payload, $method = 'post')
+  public function send($path, $payload = null, $method = 'post', $filterNullValues = true)
   {
+    if ($filterNullValues && is_array($payload)) {
+      $payload = array_filter($payload, function($value) {
+        return $value !== null;
+      });
+    }
+
     $this->preCheck();
 
     $request = new AuthsignalRequestTransport();
-    $request->send($method, self::apiUrl($url), $payload);
+    $request->send($method, self::apiUrl($path), $payload);
 
     return $this->handleResponse($request);
   }

--- a/test/AuthsignalTest.php
+++ b/test/AuthsignalTest.php
@@ -206,12 +206,12 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
         $this->assertEquals($response["success"], true);
     }
 
-    public function testDeleteUserAuthenticator() {
+    public function testDeleteAuthenticator() {
         $mockedResponse = array("success" => true);
     
         self::$server->setResponseOfPath("/v1/users/123%3Atest/authenticators/456%3Atest", new Response(json_encode($mockedResponse), [], 200));
     
-        $response = Authsignal::deleteUserAuthenticator("123:test", "456:test");
+        $response = Authsignal::deleteAuthenticator("123:test", "456:test");
     
         $this->assertArrayHasKey("success", $response);
         $this->assertEquals($response["success"], true);

--- a/test/AuthsignalTest.php
+++ b/test/AuthsignalTest.php
@@ -173,7 +173,7 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
               "idempotencyKey" => "5924a649-b5d3-4baf-a4ab-4b812dde97a0",
               "stateUpdatedAt" => "2022-07-25T03:19:00.316Z",
               "userId" => null,
-              "action" => "another_action",
+              "action" => "malicious_action",
               "isValid" => "false",
               "verificationMethod" => "AUTHENTICATOR_APP");
 

--- a/test/AuthsignalTest.php
+++ b/test/AuthsignalTest.php
@@ -169,16 +169,13 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
     }
 
     public function testValidateChallengeInvalidAction() {
-        $mockedResponse = array("state" => "CHALLENGE_SUCCEEDED",
-              "idempotencyKey" => "5924a649-b5d3-4baf-a4ab-4b812dde97a0",
-              "stateUpdatedAt" => "2022-07-25T03:19:00.316Z",
-              "userId" => null,
-              "action" => "malicious_action",
-              "isValid" => "false",
-              "verificationMethod" => "AUTHENTICATOR_APP");
-
-              self::$server->setResponseOfPath("/v1/validate", new Response(json_encode($mockedResponse)));
-
+        $mockedResponse = array(
+            "isValid" => false,
+            "error" => "Action is invalid."
+        );
+    
+        self::$server->setResponseOfPath("/v1/validate", new Response(json_encode($mockedResponse)));
+    
         $key = "secret";
         $testTokenPayload = [
             'iss' => 'http://example.org',
@@ -192,10 +189,11 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
             ]
         ];
         $token = JWT::encode($testTokenPayload, $key, 'HS256');
-
-        $response = Authsignal::validateChallenge(token: $token);
-
-        $this->assertEquals($response["isValid"], "false");
+    
+        $response = Authsignal::validateChallenge(token: $token, action: "malicious_action");
+    
+        $this->assertEquals($response["isValid"], false);
+        $this->assertEquals($response["error"], "Action is invalid.");
     }
 
     public function testDeleteUser() {


### PR DESCRIPTION
**3.0.0**
**Breaking Changes:**

- Rename `deleteUserAuthenticator` to `deleteAuthenticator` for consistency. 
- Omit deprecated `actionCode` from `validateChallenge` response.

**Other changes:**

- Omit keys with null values from API requests by default.
- Add action option in `validateChallenge` method: Ensures that the validated action matches the tracked action when the action parameter is provided.
