### PR TITLE
Update sdk to match authsignal's general sdk conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ An example setting the client to use the AU region.
 Authsignal::setApiHostname("https://au.signal.authsignal.com");
 ```
 
-Alternatively, an environment variable can be used to set the base URL:
+Alternatively, an environment variable can be used to set the API URL:
 
 ```bash
 AUTHSIGNAL_SERVER_API_ENDPOINT=https://au.signal.authsignal.com/v1

--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ Authsignal has multiple api hosting regions. To view your hostname for your tena
 | AU (Sydney) | https://au.signal.authsignal.com/v1 |
 | EU (Dublin) | https://eu.signal.authsignal.com/v1 |
 
-You can set the hostname via the following code. If the `setApiHostname` function is not called, the api call defaults to the main Authsignal US region hostname `https://signal.authsignal.com`
+You can set the hostname via the following code. If the `setApiUrl` function is not called, the api call defaults to the main Authsignal US region hostname `https://signal.authsignal.com`
 
 An example setting the client to use the AU region.
 
 ```php
-Authsignal::setApiHostname("https://au.signal.authsignal.com");
+Authsignal::setApiUrl("https://au.signal.authsignal.com");
 ```
 
 Alternatively, an environment variable can be used to set the API URL:

--- a/README.md
+++ b/README.md
@@ -53,6 +53,21 @@ Authsignal's server side signal API has five main calls `track`, `getAction`, `g
 
 For more details on these api calls, refer to our [official PHP SDK docs](https://docs.authsignal.com/sdks/server/php#trackaction).
 
+### Response & Error handling
+
+Example:
+
+```php
+$result = Authsignal::updateAction(
+   userId: $userId,
+   action: $action,
+   idempotencyKey: "invalidKey",
+   attributes: ['state' => 'CHALLENGE_FAILED']
+);
+
+# PHP Fatal error: Uncaught AuthsignalNotFoundError: 404 - not_found
+```
+
 ## License
 
 The library is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ You can set the hostname via the following code. If the `setApiUrl` function is 
 An example setting the client to use the AU region.
 
 ```php
-Authsignal::setApiUrl("https://au.signal.authsignal.com");
+Authsignal::setApiUrl("https://au.signal.authsignal.com/v1");
 ```
 
 Alternatively, an environment variable can be used to set the API URL:
 
 ```bash
-AUTHSIGNAL_SERVER_API_ENDPOINT=https://au.signal.authsignal.com/v1
+AUTHSIGNAL_API_URL=https://au.signal.authsignal.com/v1
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Check out our [official PHP SDK documentation](https://docs.authsignal.com/sdks/
 Initialize the Authsignal SDK, ensuring you do not hard code the Authsignal Secret Key, always keep this safe.
 
 ```php
-Authsignal::setApiKey('secretKey');
+Authsignal::setApiSecretKey('secretKey');
 ```
 
 You can find your `secretKey` in the [Authsignal Portal](https://portal.authsignal.com/organisations/tenants/api).

--- a/lib/Authsignal/Authsignal.php
+++ b/lib/Authsignal/Authsignal.php
@@ -210,4 +210,23 @@ abstract class Authsignal
     
     return $response;
   }
+
+  /**
+   * Update Action
+   * Updates the state of an action for a user
+   * @param  string  $userId The userId of the user to update the action for
+   * @param  string  $action The action code to update
+   * @param  string  $idempotencyKey The idempotency key for the action
+   * @param  array   $attributes Additional attributes for the action
+   * @return array   The Authsignal response
+   */
+  public static function updateAction(string $userId, string $action, string $idempotencyKey, array $attributes)
+  {
+    $request = new AuthsignalClient();
+    $path = "/users/" . urlencode($userId) . "/actions/" . urlencode($action) . "/" . urlencode($idempotencyKey);
+
+    list($response, $request) = $request->send($path, $attributes, 'patch');
+    return $response;
+  }
+
 }

--- a/lib/Authsignal/Authsignal.php
+++ b/lib/Authsignal/Authsignal.php
@@ -65,17 +65,20 @@ abstract class Authsignal
 
   /**
    * Track an action
-   * @param  string  $userId The userId of the user you are tracking the action for
-   * @param  string  $action The action code that you are tracking
-   * @param  Array  $payload An array of attributes to track.
-   * @return Array  The authsignal response
+   * 
+   * @param array $params An associative array of parameters:
+   *                      - string 'userId': The userId of the user you are tracking the action for
+   *                      - string 'action': The action code that you are tracking
+   *                      - array 'attributes': An array of attributes to track
+   * @return array The authsignal response
    */
-  public static function track(string $userId, string $action, Array $payload)
+  public static function track(array $params)
   {
     $request = new AuthsignalClient();
-    $userId = urlencode($userId);
-    $action = urlencode($action);
-    list($response, $request) = $request->send("/users/{$userId}/actions/{$action}", $payload, 'post');
+    $userId = urlencode($params['userId']);
+    $action = urlencode($params['action']);
+    $attributes = $params['attributes'];
+    list($response, $request) = $request->send("/users/{$userId}/actions/{$action}", $attributes, 'post');
     
     return $response;
   }

--- a/lib/Authsignal/Authsignal.php
+++ b/lib/Authsignal/Authsignal.php
@@ -135,15 +135,15 @@ abstract class Authsignal
    * Enroll Authenticators
    * @param array $params An associative array of parameters:
    *                      - string 'userId': The userId of the user you are tracking the action for
-   *                      - array 'authenticator': The authenticator object
+   *                      - array 'attributes': The authenticator object
    * @return Array  The authsignal response
    */
   public static function enrollVerifiedAuthenticator(array $params)
   {
     $request = new AuthsignalClient();
     $userId = urlencode($params['userId']);
-    $authenticator = $params['authenticator'];
-    list($response, $request) = $request->send("/users/{$userId}/authenticators", $authenticator, 'post');
+    $attributes = $params['attributes'];
+    list($response, $request) = $request->send("/users/{$userId}/authenticators", $attributes, 'post');
 
     return $response;
   }

--- a/lib/Authsignal/Authsignal.php
+++ b/lib/Authsignal/Authsignal.php
@@ -123,9 +123,9 @@ abstract class Authsignal
   {
       $request = new AuthsignalClient();
       $userId = urlencode($params['userId']);
-      $data = $params['data'];
+      $attributes = $params['attributes'];
       $path = "/users/{$userId}";
-      list($response, $request) = $request->send($path, $data, 'post');
+      list($response, $request) = $request->send($path, $attributes, 'post');
       return $response;
   }
   

--- a/lib/Authsignal/Authsignal.php
+++ b/lib/Authsignal/Authsignal.php
@@ -106,16 +106,14 @@ abstract class Authsignal
    * Get a user
    * @param array $params An associative array of parameters:
    *                      - string 'userId': The userId of the user you are tracking the action for
-   *                      - string|null 'redirectUrl': The redirectUrl if using the redirect flow (optional)
    * @return Array  The authsignal response
    */
   public static function getUser(array $params)
   {
     $request = new AuthsignalClient();
     $userId = urlencode($params['userId']);
-    $redirectUrl = isset($params['redirectUrl']) ? urlencode($params['redirectUrl']) : null;
 
-    $path = empty($redirectUrl) ? "/users/{$userId}" : "/users/{$userId}?redirectUrl={$redirectUrl}";
+    $path = "/users/{$userId}";
     list($response, $request) = $request->send($path, null, 'get');
 
     return $response;

--- a/lib/Authsignal/Authsignal.php
+++ b/lib/Authsignal/Authsignal.php
@@ -7,7 +7,7 @@ abstract class Authsignal
 {
   const VERSION = '3.0.1';
 
-  public static $apiKey;
+  public static $apiSecretKey;
 
   public static $apiHostname = 'https://signal.authsignal.com';
 
@@ -19,14 +19,14 @@ abstract class Authsignal
                                         CURLOPT_TIMEOUT,
                                         CURLOPT_TIMEOUT_MS);
 
-  public static function getApiKey()
+  public static function getApiSecretKey()
   {
-    return self::$apiKey;
+    return self::$apiSecretKey;
   }
 
-  public static function setApiKey($apiKey)
+  public static function setApiSecretKey($apiSecretKey)
   {
-    self::$apiKey = $apiKey;
+    self::$apiSecretKey = $apiSecretKey;
   }
 
   public static function setApiHostname($hostname)

--- a/lib/Authsignal/Authsignal.php
+++ b/lib/Authsignal/Authsignal.php
@@ -64,45 +64,6 @@ abstract class Authsignal
   }
 
   /**
-   * Track an action
-   * 
-   * @param array $params An associative array of parameters:
-   *                      - string 'userId': The userId of the user you are tracking the action for
-   *                      - string 'action': The action code that you are tracking
-   *                      - array 'attributes': An array of attributes to track
-   * @return array The authsignal response
-   */
-  public static function track(array $params)
-  {
-    $request = new AuthsignalClient();
-    $userId = urlencode($params['userId']);
-    $action = urlencode($params['action']);
-    $attributes = $params['attributes'];
-    list($response, $request) = $request->send("/users/{$userId}/actions/{$action}", $attributes, 'post');
-    
-    return $response;
-  }
-
-  /**
-   * Get an action
-   * @param array $params An associative array of parameters:
-   *                      - string 'userId': The userId of the user you are tracking the action for
-   *                      - string 'action': The action code that you are tracking
-   *                      - string 'idempotencyKey': The idempotency key for the action
-   * @return Array  The authsignal response
-   */
-  public static function getAction(array $params)
-  {
-    $request = new AuthsignalClient();
-    $userId = urlencode($params['userId']);
-    $action = urlencode($params['action']);
-    $idempotencyKey = urlencode($params['idempotencyKey']);
-    list($response, $request) = $request->send("/users/{$userId}/actions/{$action}/{$idempotencyKey}", array(), 'get');
-
-    return $response;
-  }
-
-  /**
    * Get a user
    * @param array $params An associative array of parameters:
    *                      - string 'userId': The userId of the user you are tracking the action for
@@ -135,9 +96,42 @@ abstract class Authsignal
       list($response, $request) = $request->send($path, $attributes, 'post');
       return $response;
   }
-  
 
   /**
+   * Delete a user
+   * @param array $params An associative array of parameters:
+   *                      - string 'userId': The userId of the user you want to delete
+   * @return Array  The authsignal response
+   */
+  public static function deleteUser(array $params)
+  {
+    $request = new AuthsignalClient();
+    $userId = urlencode($params['userId']);
+    $path = "/users/{$userId}";
+    list($response, $request) = $request->send($path, null, 'delete');
+    return $response;
+  }
+
+
+  /**
+   * Get Authenticators
+   * @param array $params An associative array of parameters:
+   *                      - string 'userId': The userId of the user whose authenticators you want to retrieve
+   * @return array The list of user authenticators
+   * @throws AuthsignalApiException if the request fails
+   */
+  public static function getAuthenticators(array $params)
+  {
+    $request = new AuthsignalClient();
+    $userId = urlencode($params['userId']);
+    $path = "/users/{$userId}/authenticators";
+    
+    list($response, $request) = $request->send($path, null, 'get');
+    return $response; 
+  }
+
+
+    /**
    * Enroll Authenticators
    * @param array $params An associative array of parameters:
    *                      - string 'userId': The userId of the user you are tracking the action for
@@ -155,22 +149,7 @@ abstract class Authsignal
   }
 
   /**
-   * Delete a user
-   * @param array $params An associative array of parameters:
-   *                      - string 'userId': The userId of the user you want to delete
-   * @return Array  The authsignal response
-   */
-  public static function deleteUser(array $params)
-  {
-    $request = new AuthsignalClient();
-    $userId = urlencode($params['userId']);
-    $path = "/users/{$userId}";
-    list($response, $request) = $request->send($path, null, 'delete');
-    return $response;
-  }
-
-  /**
-   * Delete a user authenticator
+   * Delete an authenticator
    * @param array $params An associative array of parameters:
    *                      - string 'userId': The userId of the user
    *                      - string 'userAuthenticatorId': The userAuthenticatorId of the authenticator
@@ -197,6 +176,26 @@ abstract class Authsignal
     } catch (Exception $e) {
         throw new AuthsignalApiException($e->getMessage(), $path, $e);
     }
+  }
+
+  /**
+   * Track an action
+   * 
+   * @param array $params An associative array of parameters:
+   *                      - string 'userId': The userId of the user you are tracking the action for
+   *                      - string 'action': The action code that you are tracking
+   *                      - array 'attributes': An array of attributes to track
+   * @return array The authsignal response
+   */
+  public static function track(array $params)
+  {
+    $request = new AuthsignalClient();
+    $userId = urlencode($params['userId']);
+    $action = urlencode($params['action']);
+    $attributes = $params['attributes'];
+    list($response, $request) = $request->send("/users/{$userId}/actions/{$action}", $attributes, 'post');
+    
+    return $response;
   }
 
   /**
@@ -227,6 +226,25 @@ abstract class Authsignal
   }
 
   /**
+   * Get an action
+   * @param array $params An associative array of parameters:
+   *                      - string 'userId': The userId of the user you are tracking the action for
+   *                      - string 'action': The action code that you are tracking
+   *                      - string 'idempotencyKey': The idempotency key for the action
+   * @return Array  The authsignal response
+   */
+  public static function getAction(array $params)
+  {
+    $request = new AuthsignalClient();
+    $userId = urlencode($params['userId']);
+    $action = urlencode($params['action']);
+    $idempotencyKey = urlencode($params['idempotencyKey']);
+    list($response, $request) = $request->send("/users/{$userId}/actions/{$action}/{$idempotencyKey}", array(), 'get');
+
+    return $response;
+  }
+
+  /**
    * Update Action
    * @param array $params An associative array of parameters:
    *                      - string 'userId': The userId of the user to update the action for
@@ -243,22 +261,4 @@ abstract class Authsignal
     list($response, $request) = $request->send($path, $params['attributes'], 'patch');
     return $response;
   }
-
-  /**
-   * Get Authenticators
-   * @param array $params An associative array of parameters:
-   *                      - string 'userId': The userId of the user whose authenticators you want to retrieve
-   * @return array The list of user authenticators
-   * @throws AuthsignalApiException if the request fails
-   */
-  public static function getAuthenticators(array $params)
-  {
-    $request = new AuthsignalClient();
-    $userId = urlencode($params['userId']);
-    $path = "/users/{$userId}/authenticators";
-    
-    list($response, $request) = $request->send($path, null, 'get');
-    return $response; 
-  }
-
 }

--- a/lib/Authsignal/Authsignal.php
+++ b/lib/Authsignal/Authsignal.php
@@ -184,7 +184,7 @@ abstract class Authsignal
    * @param array $params An associative array of parameters:
    *                      - string 'userId': The userId of the user you are tracking the action for
    *                      - string 'action': The action code that you are tracking
-   *                      - array 'attributes': An array of attributes to track
+   *                      - array 'attributes': An array of attributes to track (optional)
    * @return array The authsignal response
    */
   public static function track(array $params)
@@ -192,8 +192,11 @@ abstract class Authsignal
     $request = new AuthsignalClient();
     $userId = urlencode($params['userId']);
     $action = urlencode($params['action']);
-    $attributes = $params['attributes'];
-    list($response, $request) = $request->send("/users/{$userId}/actions/{$action}", $attributes, 'post');
+    $attributes = isset($params['attributes']) ? $params['attributes'] : [];
+    
+    $requestBody = ['attributes' => $attributes];
+    
+    list($response, $request) = $request->send("/users/{$userId}/actions/{$action}", $requestBody, 'post');
     
     return $response;
   }

--- a/lib/Authsignal/Authsignal.php
+++ b/lib/Authsignal/Authsignal.php
@@ -11,8 +11,6 @@ abstract class Authsignal
 
   public static $apiUrl = 'https://signal.authsignal.com';
 
-  public static $apiVersion = 'v1';
-
   private static $curlOpts = array();
   private static $validCurlOpts = array(CURLOPT_CONNECTTIMEOUT,
                                         CURLOPT_CONNECTTIMEOUT_MS,
@@ -51,16 +49,6 @@ abstract class Authsignal
   public static function getCurlOpts()
   {
     return self::$curlOpts;
-  }
-
-  public static function getApiVersion()
-  {
-    return self::$apiVersion;
-  }
-
-  public static function setApiVersion($apiVersion)
-  {
-    self::$apiVersion = $apiVersion;
   }
 
   /**

--- a/lib/Authsignal/Authsignal.php
+++ b/lib/Authsignal/Authsignal.php
@@ -237,4 +237,21 @@ abstract class Authsignal
     return $response;
   }
 
+  /**
+   * Get Authenticators
+   * @param array $params An associative array of parameters:
+   *                      - string 'userId': The userId of the user whose authenticators you want to retrieve
+   * @return array The list of user authenticators
+   * @throws AuthsignalApiException if the request fails
+   */
+  public static function getAuthenticators(array $params)
+  {
+    $request = new AuthsignalClient();
+    $userId = urlencode($params['userId']);
+    $path = "/users/{$userId}/authenticators";
+    
+    list($response, $request) = $request->send($path, null, 'get');
+    return $response; 
+  }
+
 }

--- a/lib/Authsignal/Authsignal.php
+++ b/lib/Authsignal/Authsignal.php
@@ -93,7 +93,7 @@ abstract class Authsignal
       $userId = urlencode($params['userId']);
       $attributes = $params['attributes'];
       $path = "/users/{$userId}";
-      list($response, $request) = $request->send($path, $attributes, 'post');
+      list($response, $request) = $request->send($path, $attributes, 'patch');
       return $response;
   }
 

--- a/lib/Authsignal/Authsignal.php
+++ b/lib/Authsignal/Authsignal.php
@@ -119,6 +119,13 @@ abstract class Authsignal
     return $response;
   }
 
+  /**
+   * Update User
+   * @param array $params An associative array of parameters:
+   *                      - string 'userId': The userId of the user to update
+   *                      - array 'attributes': The attributes to update for the user
+   * @return array The authsignal response
+   */
   public static function updateUser(array $params)
   {
       $request = new AuthsignalClient();

--- a/lib/Authsignal/Authsignal.php
+++ b/lib/Authsignal/Authsignal.php
@@ -9,7 +9,7 @@ abstract class Authsignal
 
   public static $apiSecretKey;
 
-  public static $apiHostname = 'https://signal.authsignal.com';
+  public static $apiUrl = 'https://signal.authsignal.com';
 
   public static $apiVersion = 'v1';
 
@@ -29,9 +29,9 @@ abstract class Authsignal
     self::$apiSecretKey = $apiSecretKey;
   }
 
-  public static function setApiHostname($hostname)
+  public static function setApiUrl($apiUrl)
   {
-    self::$apiHostname = $hostname;
+    self::$apiUrl = $apiUrl;
   }
 
   public static function setCurlOpts($curlOpts)

--- a/lib/Authsignal/AuthsignalClient.php
+++ b/lib/Authsignal/AuthsignalClient.php
@@ -6,7 +6,7 @@ class AuthsignalClient
   {
     $apiEndpoint = getenv('AUTHSIGNAL_SERVER_API_ENDPOINT');
     if ( !$apiEndpoint ) {
-      $apiURL    = Authsignal::$apiHostname;
+      $apiURL    = Authsignal::$apiUrl;
       $apiVersion = Authsignal::getApiVersion();
       $apiEndpoint = $apiURL.'/'.$apiVersion;
     }

--- a/lib/Authsignal/AuthsignalClient.php
+++ b/lib/Authsignal/AuthsignalClient.php
@@ -2,15 +2,10 @@
 
 class AuthsignalClient
 {
-  public static function apiUrl($path='')
+  public static function apiUrl($path = '')
   {
-    $apiEndpoint = getenv('AUTHSIGNAL_SERVER_API_ENDPOINT');
-    if ( !$apiEndpoint ) {
-      $apiURL    = Authsignal::$apiUrl;
-      $apiVersion = Authsignal::getApiVersion();
-      $apiEndpoint = $apiURL.'/'.$apiVersion;
-    }
-    return $apiEndpoint.$path;
+    $apiEndpoint = getenv('AUTHSIGNAL_API_URL') ?: Authsignal::$apiUrl;
+    return $apiEndpoint . $path;
   }
 
   public function handleApiError($response, $statusCode)

--- a/lib/Authsignal/AuthsignalClient.php
+++ b/lib/Authsignal/AuthsignalClient.php
@@ -6,9 +6,9 @@ class AuthsignalClient
   {
     $apiEndpoint = getenv('AUTHSIGNAL_SERVER_API_ENDPOINT');
     if ( !$apiEndpoint ) {
-      $apiBase    = Authsignal::$apiHostname;
+      $apiURL    = Authsignal::$apiHostname;
       $apiVersion = Authsignal::getApiVersion();
-      $apiEndpoint = $apiBase.'/'.$apiVersion;
+      $apiEndpoint = $apiURL.'/'.$apiVersion;
     }
     return $apiEndpoint.$path;
   }

--- a/lib/Authsignal/AuthsignalClient.php
+++ b/lib/Authsignal/AuthsignalClient.php
@@ -68,7 +68,7 @@ class AuthsignalClient
 
   public function preCheck()
   {
-    $key = Authsignal::getApiKey();
+    $key = Authsignal::getApiSecretKey();
     if (empty($key)) {
       throw new AuthsignalConfigurationError();
     }

--- a/lib/Authsignal/AuthsignalClient.php
+++ b/lib/Authsignal/AuthsignalClient.php
@@ -13,35 +13,39 @@ class AuthsignalClient
     return $apiEndpoint.$path;
   }
 
-  public function handleApiError($response, $status)
+  public function handleApiError($response, $statusCode)
   {
-    $type = $response['error'] ?? null;
-    $msg  = $response['errorDescription'] ?? null;
-    switch ($status) {
+    $errorCode = $response['errorCode'] ?? null;
+    $errorDescription  = $response['errorDescription'] ?? null;
+    switch ($statusCode) {
       case 400:
-        throw new AuthsignalBadRequest($msg, $type, $status);
+        throw new AuthsignalBadRequest($statusCode, $errorCode, $errorDescription);
       case 401:
-        throw new AuthsignalUnauthorizedError($msg, $type, $status);
+        throw new AuthsignalUnauthorizedError($statusCode, $errorCode, $errorDescription);
       case 403:
-        throw new AuthsignalForbiddenError($msg, $type, $status);
+        throw new AuthsignalForbiddenError($statusCode, $errorCode, $errorDescription);
       case 404:
-        throw new AuthsignalNotFoundError($msg, $type, $status);
+        throw new AuthsignalNotFoundError($statusCode, $errorCode, $errorDescription);
       case 422:
         // Handle subtype errors
-        switch($type) {
+        switch($errorCode) {
           case 'invalid_request_token':
-            throw new AuthsignalInvalidRequestTokenError($msg, $type, $status);
+            throw new AuthsignalInvalidRequestTokenError($statusCode, $errorCode, $errorDescription);
           default:
-            throw new AuthsignalInvalidParametersError($msg, $type, $status);
+            throw new AuthsignalInvalidParametersError($statusCode, $errorCode, $errorDescription);
         }
       default:
-        throw new AuthsignalApiError($msg, $type, $status);
+        throw new AuthsignalApiError($statusCode, $errorCode, $errorDescription);
     }
   }
 
   public function handleRequestError($request)
   {
-    throw new AuthsignalRequestError("$request->rError: $request->rMessage");
+      $statusCode = $request->rStatus; // HTTP statusCode code
+      $errorCode = $request->rError; // Error code
+      $errorDescription = $request->rMessage; // Error message
+    
+      throw new AuthsignalRequestError($statusCode, $errorCode, $errorDescription);
   }
 
   public function handleResponse($request)

--- a/lib/Authsignal/AuthsignalRequestTransport.php
+++ b/lib/Authsignal/AuthsignalRequestTransport.php
@@ -69,7 +69,7 @@ class AuthsignalRequestTransport
 
     // Set our default options.
     $curlOptions[CURLOPT_URL] = $url;
-    $curlOptions[CURLOPT_USERPWD] =  Authsignal::getApiKey() . ":";
+    $curlOptions[CURLOPT_USERPWD] =  Authsignal::getApiSecretKey() . ":";
     $curlOptions[CURLOPT_RETURNTRANSFER] = true;
     $curlOptions[CURLOPT_CONNECTTIMEOUT] = 3;
     $curlOptions[CURLOPT_TIMEOUT] = 10;

--- a/lib/Authsignal/AuthsignalRequestTransport.php
+++ b/lib/Authsignal/AuthsignalRequestTransport.php
@@ -50,6 +50,9 @@ class AuthsignalRequestTransport
       case 'put':
         curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "PUT");
         break;
+      case 'patch':
+        curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "PATCH");
+        break;
       case 'delete':
         curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "DELETE");
         break;

--- a/lib/Authsignal/Errors.php
+++ b/lib/Authsignal/Errors.php
@@ -2,7 +2,21 @@
 
 class AuthsignalError extends Exception
 {
+    public function __construct($statusCode, $errorCode, $errorDescription = null, $previous = null)
+    {
+        $message = $this->formatMessage($statusCode, $errorCode, $errorDescription);
+        parent::__construct($message, $statusCode, $previous);
+    }
 
+    private function formatMessage($statusCode, $errorCode, $errorDescription = null)
+    {
+        return "$statusCode - " . $this->formatDescription($errorCode, $errorDescription);
+    }
+
+    private function formatDescription($errorCode, $errorDescription = null)
+    {
+        return $errorDescription && strlen($errorDescription) > 0 ? $errorDescription : $errorCode;
+    }
 }
 
 class AuthsignalRequestError extends AuthsignalError
@@ -22,12 +36,7 @@ class AuthsignalCurlOptionError extends AuthsignalError
 
 class AuthsignalApiError extends AuthsignalError
 {
-  public function __construct($msg, $type = null, $status = null)
-  {
-    parent::__construct($msg);
-    $this->type = $type;
-    $this->httpStatus = $status;
-  }
+
 }
 
 class AuthsignalBadRequest extends AuthsignalApiError

--- a/test/AuthsignalTest.php
+++ b/test/AuthsignalTest.php
@@ -11,7 +11,7 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
     protected static $server;
 
     public static function setUpBeforeClass(): void {
-        Authsignal::setApiKey('secret');
+        Authsignal::setApiSecretKey('secret');
         self::$server = new MockWebServer;
         self::$server->start();
 

--- a/test/AuthsignalTest.php
+++ b/test/AuthsignalTest.php
@@ -302,4 +302,29 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
         $this->assertEquals($response[0]["userAuthenticatorId"], $mockedResponse[0]["userAuthenticatorId"]);
         $this->assertEquals($response[1]["userAuthenticatorId"], $mockedResponse[1]["userAuthenticatorId"]);
     }
+
+    public function testUpdateAction() {
+        $mockedResponse = array(
+            "userId" => "123:test",
+            "action" => "signIn",
+            "idempotencyKey" => "5924a649-b5d3-4baf-a4ab-4b812dde97a0",
+            "state" => "CHALLENGE_FAILED"
+        );
+
+        self::$server->setResponseOfPath("/v1/users/123%3Atest/actions/signIn/5924a649-b5d3-4baf-a4ab-4b812dde97a0", new Response(json_encode($mockedResponse)));
+
+        $params = array(
+            "userId" => "123:test",
+            "action" => "signIn",
+            "idempotencyKey" => "5924a649-b5d3-4baf-a4ab-4b812dde97a0",
+            "attributes" => array("state" => "CHALLENGE_FAILED")
+        );
+
+        $response = Authsignal::updateAction($params);
+
+        $this->assertEquals($response["userId"], $mockedResponse["userId"]);
+        $this->assertEquals($response["action"], $mockedResponse["action"]);
+        $this->assertEquals($response["idempotencyKey"], $mockedResponse["idempotencyKey"]);
+        $this->assertEquals($response["state"], $mockedResponse["state"]);
+    }
 }

--- a/test/AuthsignalTest.php
+++ b/test/AuthsignalTest.php
@@ -116,7 +116,7 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
 
         $params = array(
             "userId" => "123:test",
-            "authenticator" => array(
+            "attributes" => array(
                 "oobChannel" => "SMS",
                 "phoneNumber" => "+6427000000"
             )

--- a/test/AuthsignalTest.php
+++ b/test/AuthsignalTest.php
@@ -27,7 +27,7 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
               "accessToken" => "xxxx",
               "url" => "wwwww");
 
-        self::$server->setResponseOfPath("/v1/users/123%3Atest", new Response(json_encode($mockedResponse)));
+        self::$server->setResponseOfPath("/users/123%3Atest", new Response(json_encode($mockedResponse)));
 
         $params = array(
             "userId" => "123:test",
@@ -46,7 +46,7 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
             "email" => "updated_email",
         );
     
-        self::$server->setResponseOfPath("/v1/users/550e8400-e29b-41d4-a716-446655440000", new Response(json_encode($mockedResponse)));
+        self::$server->setResponseOfPath("/users/550e8400-e29b-41d4-a716-446655440000", new Response(json_encode($mockedResponse)));
     
         $params = array(
             "userId" => "550e8400-e29b-41d4-a716-446655440000",
@@ -64,7 +64,7 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
     public function testDeleteUser() {
         $mockedResponse = array("success" => true);
     
-        self::$server->setResponseOfPath("/v1/users/1234", new Response(json_encode($mockedResponse), [], 200));
+        self::$server->setResponseOfPath("/users/1234", new Response(json_encode($mockedResponse), [], 200));
     
         $params = array("userId" => "1234");
         $response = Authsignal::deleteUser($params);
@@ -88,7 +88,7 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
             )
         );
 
-        self::$server->setResponseOfPath("/v1/users/123%3Atest/authenticators", new Response(json_encode($mockedResponse)));
+        self::$server->setResponseOfPath("/users/123%3Atest/authenticators", new Response(json_encode($mockedResponse)));
 
         $params = array(
             "userId" => "123:test"
@@ -112,7 +112,7 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
                 "createdAt"=> "2022-07-25T03:31:36.219Z",
                 "oobChannel"=> "SMS"));
 
-        self::$server->setResponseOfPath("/v1/users/123%3Atest/authenticators", new Response(json_encode($mockedResponse)));
+        self::$server->setResponseOfPath("/users/123%3Atest/authenticators", new Response(json_encode($mockedResponse)));
 
         $params = array(
             "userId" => "123:test",
@@ -130,7 +130,7 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
     public function testDeleteAuthenticator() {
         $mockedResponse = array("success" => true);
     
-        self::$server->setResponseOfPath("/v1/users/123%3Atest/authenticators/456%3Atest", new Response(json_encode($mockedResponse), [], 200));
+        self::$server->setResponseOfPath("/users/123%3Atest/authenticators/456%3Atest", new Response(json_encode($mockedResponse), [], 200));
     
         $params = array(
             "userId" => "123:test",
@@ -148,7 +148,7 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
               "idempotencyKey" => "5924a649-b5d3-4baf-a4ab-4b812dde97a0",
               "ruleIds" => []);
 
-        self::$server->setResponseOfPath('/v1/users/123%3Atest/actions/signIn', new Response(json_encode($mockedResponse)));
+        self::$server->setResponseOfPath('/users/123%3Atest/actions/signIn', new Response(json_encode($mockedResponse)));
 
         $params = array(
             "userId" => "123:test",
@@ -182,7 +182,7 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
               "action" => "signIn",
               "verificationMethod" => "AUTHENTICATOR_APP");
 
-        self::$server->setResponseOfPath("/v1/validate", new Response(json_encode($mockedResponse)));
+        self::$server->setResponseOfPath("/validate", new Response(json_encode($mockedResponse)));
 
         $key = "secret";
         $testTokenPayload = [
@@ -217,7 +217,7 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
               "createdAt" => "2022-07-25T03:19:00.316Z",
               "ruleIds" => []);
 
-        self::$server->setResponseOfPath("/v1/users/123%3Atest/actions/signIn/5924a649-b5d3-4baf-a4ab-4b812dde97a04", new Response(json_encode($mockedResponse)));
+        self::$server->setResponseOfPath("/users/123%3Atest/actions/signIn/5924a649-b5d3-4baf-a4ab-4b812dde97a04", new Response(json_encode($mockedResponse)));
 
         $params = array(
             "userId" => "123:test",
@@ -240,7 +240,7 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
             "state" => "CHALLENGE_FAILED"
         );
 
-        self::$server->setResponseOfPath("/v1/users/123%3Atest/actions/signIn/5924a649-b5d3-4baf-a4ab-4b812dde97a0", new Response(json_encode($mockedResponse)));
+        self::$server->setResponseOfPath("/users/123%3Atest/actions/signIn/5924a649-b5d3-4baf-a4ab-4b812dde97a0", new Response(json_encode($mockedResponse)));
 
         $params = array(
             "userId" => "123:test",

--- a/test/AuthsignalTest.php
+++ b/test/AuthsignalTest.php
@@ -1,31 +1,28 @@
-
 <?php
 
 require_once dirname(__DIR__) . '/vendor/autoload.php';
 
 use donatj\MockWebServer\MockWebServer;
 use donatj\MockWebServer\Response;
-
 use Firebase\JWT\JWT;
 
 class AuthsignalTest extends PHPUnit\Framework\TestCase {
     /** @var MockWebServer */
-	protected static $server;
+    protected static $server;
 
     public static function setUpBeforeClass(): void {
         Authsignal::setApiKey('secret');
         self::$server = new MockWebServer;
-		self::$server->start();
+        self::$server->start();
 
         Authsignal::setApiHostname(self::$server->getServerRoot());
     }
 
     static function tearDownAfterClass(): void {
-		self::$server->stop();
-	}
+        self::$server->stop();
+    }
 
-    public function testSetApiKey()
-    {
+    public function testSetApiKey() {
         $this->assertEquals('secret', Authsignal::getApiKey());
     }
 
@@ -37,27 +34,30 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
 
         self::$server->setResponseOfPath('/v1/users/123%3Atest/actions/signIn', new Response(json_encode($mockedResponse)));
 
-        $payload = array(
-            "redirectUrl" => "https://www.yourapp.com/back_to_your_app",
-            "email" => "test@email",
-            "deviceId" => "123",
-            "userAgent" => "Mozilla/5.0 (platform; rv:geckoversion) Gecko/geckotrail Firefox/firefoxversion",
-            "ipAddress" => "1.1.1.1",
-            "custom" => array(
-              "yourCustomBoolean" => true,
-              "yourCustomString" => true,
-              "yourCustomNumber" => 1.12
-            ));
+        $params = array(
+            "userId" => "123:test",
+            "action" => "signIn",
+            "attributes" => array(
+                "redirectUrl" => "https://www.yourapp.com/back_to_your_app",
+                "email" => "test@email",
+                "deviceId" => "123",
+                "userAgent" => "Mozilla/5.0 (platform; rv:geckoversion) Gecko/geckotrail Firefox/firefoxversion",
+                "ipAddress" => "1.1.1.1",
+                "custom" => array(
+                    "yourCustomBoolean" => true,
+                    "yourCustomString" => true,
+                    "yourCustomNumber" => 1.12
+                )
+            )
+        );
 
-        $response = Authsignal::track(userId: "123:test",
-                                            action: "signIn",
-                                            payload: $payload);
+        $response = Authsignal::track($params);
 
         $this->assertEquals($response["state"], "ALLOW");
         $this->assertEquals($response["idempotencyKey"], $mockedResponse["idempotencyKey"]);
     }
 
-    public function testgetAction() {
+    public function testGetAction() {
         // Mock response
         $mockedResponse = array("state" => "ALLOW",
               "idempotencyKey" => "5924a649-b5d3-4baf-a4ab-4b812dde97a0",
@@ -67,22 +67,32 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
 
         self::$server->setResponseOfPath("/v1/users/123%3Atest/actions/signIn/5924a649-b5d3-4baf-a4ab-4b812dde97a04", new Response(json_encode($mockedResponse)));
 
-        $response = Authsignal::getAction(userId: "123:test",
-                                            action: "signIn",
-                                            idempotencyKey: "5924a649-b5d3-4baf-a4ab-4b812dde97a04");
+        $params = array(
+            "userId" => "123:test",
+            "action" => "signIn",
+            "idempotencyKey" => "5924a649-b5d3-4baf-a4ab-4b812dde97a04"
+        );
+
+        $response = Authsignal::getAction($params);
 
         $this->assertEquals($response["state"], "ALLOW");
         $this->assertEquals($response["idempotencyKey"], $mockedResponse["idempotencyKey"]);
         $this->assertEquals($response["stateUpdatedAt"], $mockedResponse["stateUpdatedAt"]);
     }
 
-    public function testgetUser() {
+    public function testGetUser() {
         $mockedResponse = array("isEnrolled" => false,
               "accessToken" => "xxxx",
               "url" => "wwwww");
 
         self::$server->setResponseOfPath("/v1/users/123%3Atest", new Response(json_encode($mockedResponse)));
-        $response = Authsignal::getUser(userId: "123:test", redirectUrl: "https://www.example.com/");
+
+        $params = array(
+            "userId" => "123:test",
+            "redirectUrl" => "https://www.example.com/"
+        );
+
+        $response = Authsignal::getUser($params);
         
         $this->assertEquals($response["isEnrolled"], $mockedResponse["isEnrolled"]);
         $this->assertEquals($response["url"], $mockedResponse["url"]);
@@ -100,9 +110,15 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
 
         self::$server->setResponseOfPath("/v1/users/123%3Atest/authenticators", new Response(json_encode($mockedResponse)));
 
-        $response = Authsignal::enrollVerifiedAuthenticator(userId: "123:test",
-                                                   authenticator: array("oobChannel" => "SMS"
-                                                                ,"phoneNumber" => "+6427000000"));
+        $params = array(
+            "userId" => "123:test",
+            "authenticator" => array(
+                "oobChannel" => "SMS",
+                "phoneNumber" => "+6427000000"
+            )
+        );
+
+        $response = Authsignal::enrollVerifiedAuthenticator($params);
         
         $this->assertEquals($response["authenticator"]["userAuthenticatorId"], $mockedResponse["authenticator"]["userAuthenticatorId"]);
     }
@@ -133,7 +149,12 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
         ];
         $token = JWT::encode($testTokenPayload, $key, 'HS256');
 
-        $response = Authsignal::validateChallenge(userId: "123:test", token: $token);
+        $params = array(
+            "userId" => "123:test",
+            "token" => $token
+        );
+
+        $response = Authsignal::validateChallenge($params);
 
         $this->assertEquals($response['isValid'], "true");
     }
@@ -147,7 +168,7 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
               "action" => "signIn",
               "verificationMethod" => "AUTHENTICATOR_APP");
 
-              self::$server->setResponseOfPath("/v1/validate", new Response(json_encode($mockedResponse)));
+        self::$server->setResponseOfPath("/v1/validate", new Response(json_encode($mockedResponse)));
 
         $key = "secret";
         $testTokenPayload = [
@@ -163,7 +184,11 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
         ];
         $token = JWT::encode($testTokenPayload, $key, 'HS256');
 
-        $response = Authsignal::validateChallenge(token: $token);
+        $params = array(
+            "token" => $token
+        );
+
+        $response = Authsignal::validateChallenge($params);
 
         $this->assertEquals($response["isValid"], "true");
     }
@@ -190,7 +215,12 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
         ];
         $token = JWT::encode($testTokenPayload, $key, 'HS256');
     
-        $response = Authsignal::validateChallenge(token: $token, action: "malicious_action");
+        $params = array(
+            "token" => $token,
+            "action" => "malicious_action"
+        );
+    
+        $response = Authsignal::validateChallenge($params);
     
         $this->assertEquals($response["isValid"], false);
         $this->assertEquals($response["error"], "Action is invalid.");
@@ -201,7 +231,8 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
     
         self::$server->setResponseOfPath("/v1/users/1234", new Response(json_encode($mockedResponse), [], 200));
     
-        $response = Authsignal::deleteUser("1234");
+        $params = array("userId" => "1234");
+        $response = Authsignal::deleteUser($params);
     
         $this->assertEquals($response["success"], true);
     }
@@ -211,7 +242,11 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
     
         self::$server->setResponseOfPath("/v1/users/123%3Atest/authenticators/456%3Atest", new Response(json_encode($mockedResponse), [], 200));
     
-        $response = Authsignal::deleteAuthenticator("123:test", "456:test");
+        $params = array(
+            "userId" => "123:test",
+            "userAuthenticatorId" => "456:test"
+        );
+        $response = Authsignal::deleteAuthenticator($params);
     
         $this->assertArrayHasKey("success", $response);
         $this->assertEquals($response["success"], true);
@@ -225,13 +260,46 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
     
         self::$server->setResponseOfPath("/v1/users/550e8400-e29b-41d4-a716-446655440000", new Response(json_encode($mockedResponse)));
     
-        $data = array(
-            "email" => "updated_email",
+        $params = array(
+            "userId" => "550e8400-e29b-41d4-a716-446655440000",
+            "attributes" => array(
+                "email" => "updated_email",
+            )
         );
     
-        $response = Authsignal::updateUser("550e8400-e29b-41d4-a716-446655440000", $data);
+        $response = Authsignal::updateUser($params);
     
         $this->assertEquals($response["userId"], $mockedResponse["userId"]);
         $this->assertEquals($response["email"], $mockedResponse["email"]);
+    }
+
+    public function testGetAuthenticators() {
+        $mockedResponse = array(
+            array(
+                "userAuthenticatorId" => "authenticator_id_1",
+                "authenticatorType" => "SMS",
+                "isDefault" => true,
+                "phoneNumber" => "+6427000000"
+            ),
+            array(
+                "userAuthenticatorId" => "authenticator_id_2",
+                "authenticatorType" => "EMAIL",
+                "isDefault" => false,
+                "email" => "user@example.com"
+            )
+        );
+
+        self::$server->setResponseOfPath("/v1/users/123%3Atest/authenticators", new Response(json_encode($mockedResponse)));
+
+        $params = array(
+            "userId" => "123:test"
+        );
+
+        $response = Authsignal::getAuthenticators($params);
+
+        $this->assertIsArray($response);
+        $this->assertCount(2, $response);
+        $this->assertEquals($response[0]["userAuthenticatorId"], $mockedResponse[0]["userAuthenticatorId"]);
+        $this->assertEquals($response[1]["userAuthenticatorId"], $mockedResponse[1]["userAuthenticatorId"]);
     }
 }

--- a/test/AuthsignalTest.php
+++ b/test/AuthsignalTest.php
@@ -22,8 +22,124 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
         self::$server->stop();
     }
 
-    public function testSetApiKey() {
-        $this->assertEquals('secret', Authsignal::getApiKey());
+    public function testGetUser() {
+        $mockedResponse = array("isEnrolled" => false,
+              "accessToken" => "xxxx",
+              "url" => "wwwww");
+
+        self::$server->setResponseOfPath("/v1/users/123%3Atest", new Response(json_encode($mockedResponse)));
+
+        $params = array(
+            "userId" => "123:test",
+            "redirectUrl" => "https://www.example.com/"
+        );
+
+        $response = Authsignal::getUser($params);
+        
+        $this->assertEquals($response["isEnrolled"], $mockedResponse["isEnrolled"]);
+        $this->assertEquals($response["url"], $mockedResponse["url"]);
+    }
+
+    public function testUpdateUser() {
+        $mockedResponse = array(
+            "userId" => "550e8400-e29b-41d4-a716-446655440000",
+            "email" => "updated_email",
+        );
+    
+        self::$server->setResponseOfPath("/v1/users/550e8400-e29b-41d4-a716-446655440000", new Response(json_encode($mockedResponse)));
+    
+        $params = array(
+            "userId" => "550e8400-e29b-41d4-a716-446655440000",
+            "attributes" => array(
+                "email" => "updated_email",
+            )
+        );
+    
+        $response = Authsignal::updateUser($params);
+    
+        $this->assertEquals($response["userId"], $mockedResponse["userId"]);
+        $this->assertEquals($response["email"], $mockedResponse["email"]);
+    }
+
+    public function testDeleteUser() {
+        $mockedResponse = array("success" => true);
+    
+        self::$server->setResponseOfPath("/v1/users/1234", new Response(json_encode($mockedResponse), [], 200));
+    
+        $params = array("userId" => "1234");
+        $response = Authsignal::deleteUser($params);
+    
+        $this->assertEquals($response["success"], true);
+    }
+
+    public function testGetAuthenticators() {
+        $mockedResponse = array(
+            array(
+                "userAuthenticatorId" => "authenticator_id_1",
+                "authenticatorType" => "SMS",
+                "isDefault" => true,
+                "phoneNumber" => "+6427000000"
+            ),
+            array(
+                "userAuthenticatorId" => "authenticator_id_2",
+                "authenticatorType" => "EMAIL",
+                "isDefault" => false,
+                "email" => "user@example.com"
+            )
+        );
+
+        self::$server->setResponseOfPath("/v1/users/123%3Atest/authenticators", new Response(json_encode($mockedResponse)));
+
+        $params = array(
+            "userId" => "123:test"
+        );
+
+        $response = Authsignal::getAuthenticators($params);
+
+        $this->assertIsArray($response);
+        $this->assertCount(2, $response);
+        $this->assertEquals($response[0]["userAuthenticatorId"], $mockedResponse[0]["userAuthenticatorId"]);
+        $this->assertEquals($response[1]["userAuthenticatorId"], $mockedResponse[1]["userAuthenticatorId"]);
+    }
+
+    public function testEnrollVerifiedAuthenticator() {
+        $mockedResponse = array(
+            "authenticator" => array(
+                "userAuthenticatorId" => "9b2cfd40-7df2-4658-852d-a0c3456e5a2e",
+                "authenticatorType" => "OOB",
+                "isDefault" => true,
+                "phoneNumber"=> "+6427000000",
+                "createdAt"=> "2022-07-25T03:31:36.219Z",
+                "oobChannel"=> "SMS"));
+
+        self::$server->setResponseOfPath("/v1/users/123%3Atest/authenticators", new Response(json_encode($mockedResponse)));
+
+        $params = array(
+            "userId" => "123:test",
+            "authenticator" => array(
+                "oobChannel" => "SMS",
+                "phoneNumber" => "+6427000000"
+            )
+        );
+
+        $response = Authsignal::enrollVerifiedAuthenticator($params);
+        
+        $this->assertEquals($response["authenticator"]["userAuthenticatorId"], $mockedResponse["authenticator"]["userAuthenticatorId"]);
+    }
+
+    public function testDeleteAuthenticator() {
+        $mockedResponse = array("success" => true);
+    
+        self::$server->setResponseOfPath("/v1/users/123%3Atest/authenticators/456%3Atest", new Response(json_encode($mockedResponse), [], 200));
+    
+        $params = array(
+            "userId" => "123:test",
+            "userAuthenticatorId" => "456:test"
+        );
+        $response = Authsignal::deleteAuthenticator($params);
+    
+        $this->assertArrayHasKey("success", $response);
+        $this->assertEquals($response["success"], true);
     }
 
     public function testTrackAction() {
@@ -55,72 +171,6 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
 
         $this->assertEquals($response["state"], "ALLOW");
         $this->assertEquals($response["idempotencyKey"], $mockedResponse["idempotencyKey"]);
-    }
-
-    public function testGetAction() {
-        // Mock response
-        $mockedResponse = array("state" => "ALLOW",
-              "idempotencyKey" => "5924a649-b5d3-4baf-a4ab-4b812dde97a0",
-              "stateUpdatedAt" => "2022-07-25T03:19:00.316Z",
-              "createdAt" => "2022-07-25T03:19:00.316Z",
-              "ruleIds" => []);
-
-        self::$server->setResponseOfPath("/v1/users/123%3Atest/actions/signIn/5924a649-b5d3-4baf-a4ab-4b812dde97a04", new Response(json_encode($mockedResponse)));
-
-        $params = array(
-            "userId" => "123:test",
-            "action" => "signIn",
-            "idempotencyKey" => "5924a649-b5d3-4baf-a4ab-4b812dde97a04"
-        );
-
-        $response = Authsignal::getAction($params);
-
-        $this->assertEquals($response["state"], "ALLOW");
-        $this->assertEquals($response["idempotencyKey"], $mockedResponse["idempotencyKey"]);
-        $this->assertEquals($response["stateUpdatedAt"], $mockedResponse["stateUpdatedAt"]);
-    }
-
-    public function testGetUser() {
-        $mockedResponse = array("isEnrolled" => false,
-              "accessToken" => "xxxx",
-              "url" => "wwwww");
-
-        self::$server->setResponseOfPath("/v1/users/123%3Atest", new Response(json_encode($mockedResponse)));
-
-        $params = array(
-            "userId" => "123:test",
-            "redirectUrl" => "https://www.example.com/"
-        );
-
-        $response = Authsignal::getUser($params);
-        
-        $this->assertEquals($response["isEnrolled"], $mockedResponse["isEnrolled"]);
-        $this->assertEquals($response["url"], $mockedResponse["url"]);
-    }   
-
-    public function testEnrollVerifiedAuthenticator() {
-        $mockedResponse = array(
-            "authenticator" => array(
-                "userAuthenticatorId" => "9b2cfd40-7df2-4658-852d-a0c3456e5a2e",
-                "authenticatorType" => "OOB",
-                "isDefault" => true,
-                "phoneNumber"=> "+6427000000",
-                "createdAt"=> "2022-07-25T03:31:36.219Z",
-                "oobChannel"=> "SMS"));
-
-        self::$server->setResponseOfPath("/v1/users/123%3Atest/authenticators", new Response(json_encode($mockedResponse)));
-
-        $params = array(
-            "userId" => "123:test",
-            "authenticator" => array(
-                "oobChannel" => "SMS",
-                "phoneNumber" => "+6427000000"
-            )
-        );
-
-        $response = Authsignal::enrollVerifiedAuthenticator($params);
-        
-        $this->assertEquals($response["authenticator"]["userAuthenticatorId"], $mockedResponse["authenticator"]["userAuthenticatorId"]);
     }
 
     public function testValidateChallenge() {
@@ -159,148 +209,27 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
         $this->assertEquals($response['isValid'], "true");
     }
 
-    public function testValidateChallengeOptionalUserId() {
-        $mockedResponse = array("state" => "CHALLENGE_SUCCEEDED",
+    public function testGetAction() {
+        // Mock response
+        $mockedResponse = array("state" => "ALLOW",
               "idempotencyKey" => "5924a649-b5d3-4baf-a4ab-4b812dde97a0",
               "stateUpdatedAt" => "2022-07-25T03:19:00.316Z",
-              "userId" => null,
-              "isValid" => "true",
-              "action" => "signIn",
-              "verificationMethod" => "AUTHENTICATOR_APP");
+              "createdAt" => "2022-07-25T03:19:00.316Z",
+              "ruleIds" => []);
 
-        self::$server->setResponseOfPath("/v1/validate", new Response(json_encode($mockedResponse)));
+        self::$server->setResponseOfPath("/v1/users/123%3Atest/actions/signIn/5924a649-b5d3-4baf-a4ab-4b812dde97a04", new Response(json_encode($mockedResponse)));
 
-        $key = "secret";
-        $testTokenPayload = [
-            'iss' => 'http://example.org',
-            'aud' => 'http://example.com',
-            'iat' => 1356999524,
-            'nbf' => 1357000000,
-            'other' => [
-                'state' => "CHALLENGE_SUCCEEDED",
-                'action' => 'signIn',
-                'idempotencyKey' => "5924a649-b5d3-4baf-a4ab-4b812dde97a0",
-            ]
-        ];
-        $token = JWT::encode($testTokenPayload, $key, 'HS256');
-
-        $params = array(
-            "token" => $token
-        );
-
-        $response = Authsignal::validateChallenge($params);
-
-        $this->assertEquals($response["isValid"], "true");
-    }
-
-    public function testValidateChallengeInvalidAction() {
-        $mockedResponse = array(
-            "isValid" => false,
-            "error" => "Action is invalid."
-        );
-    
-        self::$server->setResponseOfPath("/v1/validate", new Response(json_encode($mockedResponse)));
-    
-        $key = "secret";
-        $testTokenPayload = [
-            'iss' => 'http://example.org',
-            'aud' => 'http://example.com',
-            'iat' => 1356999524,
-            'nbf' => 1357000000,
-            'other' => [
-                'state' => "CHALLENGE_SUCCEEDED",
-                'action' => 'signIn',
-                'idempotencyKey' => "5924a649-b5d3-4baf-a4ab-4b812dde97a0",
-            ]
-        ];
-        $token = JWT::encode($testTokenPayload, $key, 'HS256');
-    
-        $params = array(
-            "token" => $token,
-            "action" => "malicious_action"
-        );
-    
-        $response = Authsignal::validateChallenge($params);
-    
-        $this->assertEquals($response["isValid"], false);
-        $this->assertEquals($response["error"], "Action is invalid.");
-    }
-
-    public function testDeleteUser() {
-        $mockedResponse = array("success" => true);
-    
-        self::$server->setResponseOfPath("/v1/users/1234", new Response(json_encode($mockedResponse), [], 200));
-    
-        $params = array("userId" => "1234");
-        $response = Authsignal::deleteUser($params);
-    
-        $this->assertEquals($response["success"], true);
-    }
-
-    public function testDeleteAuthenticator() {
-        $mockedResponse = array("success" => true);
-    
-        self::$server->setResponseOfPath("/v1/users/123%3Atest/authenticators/456%3Atest", new Response(json_encode($mockedResponse), [], 200));
-    
         $params = array(
             "userId" => "123:test",
-            "userAuthenticatorId" => "456:test"
-        );
-        $response = Authsignal::deleteAuthenticator($params);
-    
-        $this->assertArrayHasKey("success", $response);
-        $this->assertEquals($response["success"], true);
-    }
-
-    public function testUpdateUser() {
-        $mockedResponse = array(
-            "userId" => "550e8400-e29b-41d4-a716-446655440000",
-            "email" => "updated_email",
-        );
-    
-        self::$server->setResponseOfPath("/v1/users/550e8400-e29b-41d4-a716-446655440000", new Response(json_encode($mockedResponse)));
-    
-        $params = array(
-            "userId" => "550e8400-e29b-41d4-a716-446655440000",
-            "attributes" => array(
-                "email" => "updated_email",
-            )
-        );
-    
-        $response = Authsignal::updateUser($params);
-    
-        $this->assertEquals($response["userId"], $mockedResponse["userId"]);
-        $this->assertEquals($response["email"], $mockedResponse["email"]);
-    }
-
-    public function testGetAuthenticators() {
-        $mockedResponse = array(
-            array(
-                "userAuthenticatorId" => "authenticator_id_1",
-                "authenticatorType" => "SMS",
-                "isDefault" => true,
-                "phoneNumber" => "+6427000000"
-            ),
-            array(
-                "userAuthenticatorId" => "authenticator_id_2",
-                "authenticatorType" => "EMAIL",
-                "isDefault" => false,
-                "email" => "user@example.com"
-            )
+            "action" => "signIn",
+            "idempotencyKey" => "5924a649-b5d3-4baf-a4ab-4b812dde97a04"
         );
 
-        self::$server->setResponseOfPath("/v1/users/123%3Atest/authenticators", new Response(json_encode($mockedResponse)));
+        $response = Authsignal::getAction($params);
 
-        $params = array(
-            "userId" => "123:test"
-        );
-
-        $response = Authsignal::getAuthenticators($params);
-
-        $this->assertIsArray($response);
-        $this->assertCount(2, $response);
-        $this->assertEquals($response[0]["userAuthenticatorId"], $mockedResponse[0]["userAuthenticatorId"]);
-        $this->assertEquals($response[1]["userAuthenticatorId"], $mockedResponse[1]["userAuthenticatorId"]);
+        $this->assertEquals($response["state"], "ALLOW");
+        $this->assertEquals($response["idempotencyKey"], $mockedResponse["idempotencyKey"]);
+        $this->assertEquals($response["stateUpdatedAt"], $mockedResponse["stateUpdatedAt"]);
     }
 
     public function testUpdateAction() {

--- a/test/AuthsignalTest.php
+++ b/test/AuthsignalTest.php
@@ -15,7 +15,7 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
         self::$server = new MockWebServer;
         self::$server->start();
 
-        Authsignal::setApiHostname(self::$server->getServerRoot());
+        Authsignal::setApiUrl(self::$server->getServerRoot());
     }
 
     static function tearDownAfterClass(): void {


### PR DESCRIPTION
## Release Notes

Changes have been made so that conventions used in the PHP SDK align with Authsignal's general SDK conventions. 

### Breaking Changes

1. **`track` Method**
   - **Old Signature**:
     ```php
     public static function track(string $userId, string $action, array $payload)
     ```
   - **New Signature**:
     ```php
     public static function track(array $params)
     ```
   - **Parameters in Associative Array**:
     - `userId` (string): The userId of the user you are tracking the action for.
     - `action` (string): The action code that you are tracking.
     - `attributes` (array): An array of attributes to track.
   - **Changes**:
     - The method now accepts a single associative array parameter named `$params`.
     - The `payload` parameter has been replaced with `attributes` in the implementation.

2. **`getAction` Method**
   - **Old Signature**:
     ```php
     public static function getAction(string $userId, string $action, string $idempotencyKey)
     ```
   - **New Signature**:
     ```php
     public static function getAction(array $params)
     ```
   - **Parameters in Associative Array**:
     - `userId` (string): The userId of the user you are tracking the action for.
     - `action` (string): The action code that you are tracking.
     - `idempotencyKey` (string): The idempotency key for the action.
   - **Changes**:
     - The method now accepts a single associative array parameter named `$params`.

3. **`getUser` Method**
   - **Old Signature**:
     ```php
     public static function getUser(string $userId, string $redirectUrl = null)
     ```
   - **New Signature**:
     ```php
     public static function getUser(array $params)
     ```
   - **Parameters in Associative Array**:
     - `userId` (string): The userId of the user you are tracking the action for.
   - **Changes**:
     - The method now accepts a single associative array parameter named `$params`.
     - Removed redirectUrl from the params.

4. **`updateUser` Method**
   - **Old Signature**:
     ```php
     public static function updateUser(string $userId, array $data)
     ```
   - **New Signature**:
     ```php
     public static function updateUser(array $params)
     ```
   - **Parameters in Associative Array**:
     - `userId` (string): The userId of the user to update.
     - `attributes ` (array): The attributes to update for the user.
   - **Changes**:
     - The method now accepts a single associative array parameter named `$params`.

5. **`enrollVerifiedAuthenticator` Method**
   - **Old Signature**:
     ```php
     public static function enrollVerifiedAuthenticator(string $userId, array $authenticator)
     ```
   - **New Signature**:
     ```php
     public static function enrollVerifiedAuthenticator(array $params)
     ```
   - **Parameters in Associative Array**:
     - `userId` (string): The userId of the user you are tracking the action for.
     - `attributes` (array): The authenticator object to enroll.
   - **Changes**:
     - The method now accepts a single associative array parameter named `$params`.

6. **`deleteUser` Method**
   - **Old Signature**:
     ```php
     public static function deleteUser(string $userId)
     ```
   - **New Signature**:
     ```php
     public static function deleteUser(array $params)
     ```
   - **Parameters in Associative Array**:
     - `userId` (string): The userId of the user you want to delete.
   - **Changes**:
     - The method now accepts a single associative array parameter named `$params`.

7. **`deleteAuthenticator` Method**
   - **Old Signature**:
     ```php
     public static function deleteAuthenticator(string $userId, string $userAuthenticatorId)
     ```
   - **New Signature**:
     ```php
     public static function deleteAuthenticator(array $params)
     ```
   - **Parameters in Associative Array**:
     - `userId` (string): The userId of the user.
     - `userAuthenticatorId` (string): The userAuthenticatorId of the authenticator to delete.
   - **Changes**:
     - The method now accepts a single associative array parameter named `$params`.

8. **`validateChallenge` Method**
   - **Old Signature**:
     ```php
     public static function validateChallenge(string $token, string $userId = null, string $action = null)
     ```
   - **New Signature**:
     ```php
     public static function validateChallenge(array $params)
     ```
   - **Parameters in Associative Array**:
     - `token` (string): The JWT token string returned on a challenge response.
     - `userId` (string|null): The userId of the user you are tracking the action for (optional).
     - `action` (string|null): The action code that you are tracking (optional).
   - **Changes**:
     - The method now accepts a single associative array parameter named `$params`.

9. **Rename`setApiKey ` Method to `setApiSecretKey`**

10. **Rename`getApiKey ` Method to `getApiSecretKey`**
11.  **Rename `setApiHostname` to `setApiUrl`**
12. **Rename `AUTHSIGNAL_SERVER_API_ENDPOINT` env var to `AUTHSIGNAL_API_URL`**
12. **Remove `setApiVersion` and `getApiVersion`**
   - The version should be set when the URL is set with `setApiUrl` or the `AUTHSIGNAL_API_URL` env variable.


### Non Breaking Changes
1. **Add `updateAction` Method**

   - **Signature**:
     ```php
     public static function updateAction(array $params)
     ```
   - **Parameters in Associative Array**:
     - `userId` (string): The userId of the user to update the action for.
     - `action` (string): The action code to update.
     - `idempotencyKey` (string): The idempotency key for the action.
     - `attributes` (array): Additional attributes for the action.
     

2. ** `getAuthenticators` Method**
- **Signature**:
  ```php
  public static function getAuthenticators(array $params)
  ```
- **Description**: Retrieves the list of authenticators for a specified user.
- **Parameters in Associative Array**:
  - `userId` (string): The userId of the user whose authenticators you want to retrieve.
- **Returns**: An array containing the list of user authenticators.
- **Throws**: 
  - `AuthsignalApiException` if the request fails.

#### Example Usage:
```php
$params = [
    'userId' => '12345' // The userId of the user whose authenticators you want to retrieve
];

$authenticators = Authsignal::getAuthenticators($params);
 