### PR TITLE
FIX: Upgrade JWT library to address CVE

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,6 @@
         "MIT"
     ],
     "require": {
-        "firebase/php-jwt": "^6.8"
+        "firebase/php-jwt": "^7"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,30 +4,30 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7fd5f1deeda5f5e1d8371cd7907662f1",
+    "content-hash": "6af88704523ebe7416f34a733ec37a98",
     "packages": [
         {
             "name": "firebase/php-jwt",
-            "version": "v6.8.1",
+            "version": "v7.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/firebase/php-jwt.git",
-                "reference": "5dbc8959427416b8ee09a100d7a8588c00fb2e26"
+                "reference": "28aa0694bcfdfa5e2959c394d5a1ee7a5083629e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/5dbc8959427416b8ee09a100d7a8588c00fb2e26",
-                "reference": "5dbc8959427416b8ee09a100d7a8588c00fb2e26",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/28aa0694bcfdfa5e2959c394d5a1ee7a5083629e",
+                "reference": "28aa0694bcfdfa5e2959c394d5a1ee7a5083629e",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.4||^8.0"
+                "php": "^8.0"
             },
             "require-dev": {
-                "guzzlehttp/guzzle": "^6.5||^7.4",
+                "guzzlehttp/guzzle": "^7.4",
                 "phpspec/prophecy-phpunit": "^2.0",
                 "phpunit/phpunit": "^9.5",
-                "psr/cache": "^1.0||^2.0",
+                "psr/cache": "^2.0||^3.0",
                 "psr/http-client": "^1.0",
                 "psr/http-factory": "^1.0"
             },
@@ -65,9 +65,9 @@
             ],
             "support": {
                 "issues": "https://github.com/firebase/php-jwt/issues",
-                "source": "https://github.com/firebase/php-jwt/tree/v6.8.1"
+                "source": "https://github.com/firebase/php-jwt/tree/v7.0.3"
             },
-            "time": "2023-07-14T18:33:00+00:00"
+            "time": "2026-02-25T22:16:40+00:00"
         }
     ],
     "packages-dev": [
@@ -1913,10 +1913,10 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }

--- a/test/AuthsignalTest.php
+++ b/test/AuthsignalTest.php
@@ -328,7 +328,7 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
         $this->assertEquals($response["idempotencyKey"], $mockedResponse["idempotencyKey"]);
     }
 
-    public function testValidateChallenge() {
+    public function testInvalidKeyBeforeChallenge() {
         $mockedResponse = array("state" => "CHALLENGE_SUCCEEDED",
               "idempotencyKey" => "5924a649-b5d3-4baf-a4ab-4b812dde97a0",
               "stateUpdatedAt" => "2022-07-25T03:19:00.316Z",
@@ -340,6 +340,44 @@ class AuthsignalTest extends PHPUnit\Framework\TestCase {
         self::$server->setResponseOfPath("/validate", new Response(json_encode($mockedResponse)));
 
         $key = "secret";
+        $testTokenPayload = [
+            'iss' => 'http://example.org',
+            'aud' => 'http://example.com',
+            'iat' => 1356999524,
+            'nbf' => 1357000000,
+            'other' => [
+                'userId' => "123:test",
+                'state' => "CHALLENGE_SUCCEEDED",
+                'action' => 'signIn',
+                'idempotencyKey' => "5924a649-b5d3-4baf-a4ab-4b812dde97a0",
+            ]
+        ];
+        $this->expectException(DomainException::class);
+        $this->expectExceptionMessage('Provided key is too short');
+        $token = JWT::encode($testTokenPayload, $key, 'HS256');
+
+        $params = array(
+            "userId" => "123:test",
+            "token" => $token
+        );
+
+        $response = Authsignal::validateChallenge($params);
+
+        $this->assertEquals($response['isValid'], "true");
+    }
+
+    public function testValidateChallenge() {
+        $mockedResponse = array("state" => "CHALLENGE_SUCCEEDED",
+              "idempotencyKey" => "5924a649-b5d3-4baf-a4ab-4b812dde97a0",
+              "stateUpdatedAt" => "2022-07-25T03:19:00.316Z",
+              "userId" => "123:test",
+              "isValid" => "true",
+              "action" => "signIn",
+              "verificationMethod" => "AUTHENTICATOR_APP");
+
+        self::$server->setResponseOfPath("/validate", new Response(json_encode($mockedResponse)));
+
+        $key = "secretKeyMustBeAtLeast32Characters";
         $testTokenPayload = [
             'iss' => 'http://example.org',
             'aud' => 'http://example.com',


### PR DESCRIPTION
### Breaking Changes
* firebase/php-jwt moves from v6 to v7.  Assuming semver, there are potentially other breaking changes that are not covered by the tests

### New Features
* firebase/php-jwt appears to have changed crypto libraries, which require use of a minimum key length

### Bug Fixes
A public CVE was released complaining about the weak encryption scheme:

- https://github.com/advisories/GHSA-2x45-7fc3-mxwq
- https://www.cve.org/CVERecord?id=CVE-2025-45769

### Checklist
- [ ] Version bumped
- [ ] Documentation updated 

Closes #42 