### PR TITLE
Bump version for veriffSessionId support

### DIFF
--- a/lib/Authsignal/Authsignal.php
+++ b/lib/Authsignal/Authsignal.php
@@ -2,7 +2,7 @@
 
 abstract class Authsignal
 {
-  const VERSION = '4.5.0';
+  const VERSION = '4.6.0';
 
   public static $apiSecretKey;
   public static $webhook;


### PR DESCRIPTION
## Summary

- The validate-challenge response now includes `veriffSessionId` when the challenge was a Veriff session.
- Bumps version to `4.6.0`.